### PR TITLE
#167806407 View a specific mentor

### DIFF
--- a/UI/mentor.html
+++ b/UI/mentor.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="stylesheet" href="pages.css">
+    <title>free-mentors|Specific Mentor</title>
+</head>
+<body>
+    <nav>
+        <div class="logo">
+            <h4>Free Mentors</h4>
+        </div>
+        <form id="search">
+            <input type="text" placeholder="search..." size="40">
+        </form>
+        <ul class="nav-links">
+            <li><a href="home.html">Home</a></li>
+            <li><a href="mentor.html"><span style="color: #fffb00">Mentors</span></a></li>
+            <li><a href="index.html">LogOut</a></li>
+        </ul>
+        <div class="burger">
+            <div class="line1"></div>
+            <div class="line2"></div>
+            <div class="line3"></div>
+        </div>
+    </nav>
+   <div class="container-box">
+       <div class="box5">
+       </div>
+        <div class="box1">
+            <h2>Mentor Profile</h2>
+            <br>
+            <span>
+                <img src="./images/profile icon.png" alt="male-icon" width="50px" height="50px">
+                <br>
+                <span>Name: John Doe</span>
+                <br>
+                <span>Email: johndoe@email.com</span>
+                <br>
+                <span>Age: 24 </span>
+                <br>
+                <span>Status: Active </span>
+                <br>
+                <br>
+                <h3>Details</h3>
+                <span>
+                    <span>Lorem ipsum dolor sit amet consectetur adipisicing elit. Natus itaque magnam totam et, provident, minus veniam sequi, optio reiciendis aliquam odit. Omnis aspernatur esse voluptatibus architecto incidunt officia? Voluptas, commodi!</span>
+                    <span>Laboriosam dolores veniam ab deserunt minima vitae dicta facere velit aspernatur, perspiciatis praesentium ut alias necessitatibus qui placeat maxime tenetur ullam aliquid beatae debitis totam expedita nesciunt! Dolorum, obcaecati quos.</span>
+                    <span>Optio deserunt sed aliquid enim delectus. Vel delectus explicabo ex non rem autem quis, deserunt ut, voluptates eveniet veniam, dicta dolorum quisquam voluptas repellendus! Ipsum enim laboriosam expedita distinctio numquam!</span>
+                 </span>
+                <br>
+                <br>
+                <br>
+                <h3>Experience</h3>
+                <span>
+                    <span>Lorem ipsum dolor sit amet consectetur adipisicing elit. Natus itaque magnam totam et, provident, minus veniam sequi, optio reiciendis aliquam odit. Omnis aspernatur esse voluptatibus architecto incidunt officia? Voluptas, commodi!</span>
+                  </span>
+                  <br>
+                  <br>
+                  <br>
+                  <br>
+
+
+            </span>
+        </div>
+        <div class="box2">
+            <h2>Specifics</h2>
+            <span>
+                <li>No. of sessions: <p>Over 100</p></li>
+                <br>
+                <li>Commitment level: <p>75%</p></li>
+                <br>
+                <li>Skillset: <p>10/10</p></li>
+                <br>
+                <li>Intelligence Quotient level: <p>99%</p></li>
+                <br>
+                <li>Emotional Quotient level: <p>89%</p></li>
+            </span>
+        </div>
+    </div>
+    <footer>
+        <div class="footer">
+            <h3>freementors@andelakigali.co</h3>
+
+        </div>
+    </footer>
+    <script src="home.js"></script>
+    <script src="text.js"></script>
+</body>
+</html>

--- a/UI/text.js
+++ b/UI/text.js
@@ -55,7 +55,6 @@ function addItem(message, id, done, trash) {
     `<li class="item">
     <input class="check ${DONE}" type="checkbox" name="check" value="" id="${id} checked"> 
     <p class="text ${DEL}">${message}</p>
-    <button class="del" id="${id}">del</button>
 </li>
     `
     const position = "beforeend"


### PR DESCRIPTION
#### What does this PR do?
- Enable specificity in interaction

#### Description of Task to be completed?
- Allows viewing of a specific mentor by clients/users.

#### How should this be manually tested?
- Navigate through the ```gh-pages``` and click on any available mentor to view their profile.

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- #167806407 ft-user-can-view-a-specific-mentor

#### Screenshots (if appropriate)
-------------------------------------------------------------------------------------------------------------
![specific mentor](https://user-images.githubusercontent.com/48585401/63306496-765a9480-c2f3-11e9-87a0-8b09fb2f3709.PNG)
--------------------------------------------------------------------------------------------------------------

#### Questions:
- N/A