### PR TITLE
#168024623 Users can view a specific mentor

### DIFF
--- a/src/controllers/mentorsController.js
+++ b/src/controllers/mentorsController.js
@@ -16,6 +16,23 @@ class MentorsController {
       data: mentors,
     });
   }
+
+  static getSingleMentor(req, res) {
+    const { mentorId } = req.params;
+    const mentor = Users.find((value) => value.id === Number(mentorId));
+
+    if (!mentor) {
+      return res.status(404).json({
+        message: 'Error',
+        error: 'Mentor not found',
+      });
+    }
+    return res.status(200).json({
+      status: 200,
+      message: 'Mentor',
+      data: mentor,
+    });
+  }
 }
 
 export default MentorsController;

--- a/src/routes/mentor.js
+++ b/src/routes/mentor.js
@@ -6,6 +6,6 @@ const mentorRouter = express.Router();
 mentorRouter.post('/', (req, res) => res.send('user signup'));
 mentorRouter.post('/:mentorId', (req, res) => res.send('user signin'));
 mentorRouter.get('/', mentorsController.allMentors);
-mentorRouter.get('/mentors/:mentorId', (req, res) => res.send('get a specific mentor'));
+mentorRouter.get('/mentors/:mentorId', mentorsController.getSingleMentor);
 
 export default mentorRouter;


### PR DESCRIPTION
#### What does this PR do?
- Have CRUD on resource endpoint ```GET/mentors/:mentorId```

#### Description of Task to be completed?
- Set up controllers to perform the task of allowing users to be able to view specific mentors when they want to. Basically ensuring the endpoint route is functional and responsive on Postman.

#### How should this be manually tested?
- ```git-clone``` this repo, cd into it and ```npm run dev```, then on **Postman** load and sign up a number of new users as per the parameters required, then basically on ``` GET a specific mentor```, type an existing ID of any mentors in the system and you should be able to view them.
 
#### Any background context you want to provide?
- Users refers to anyone using the app, that is inclusive of both mentors and mentees, as well as the admin.

#### What are the relevant pivotal tracker stories?
- #168024623 - ft-sers-can-view-a-specific-mentor

#### Screenshots (if appropriate)
- N/A
#### Questions:
- N/A