### PR TITLE
#168024660 Users can create a mentors-session requests

### DIFF
--- a/src/controllers/mentorsController.js
+++ b/src/controllers/mentorsController.js
@@ -1,6 +1,44 @@
+import jwt from 'jsonwebtoken';
 import Users from '../models/authModel';
+import Mentors from '../models/mentorModel';
+import config from '../config';
+
+const ENV_VAR = config.get(process.env.NODE_ENV);
 
 class MentorsController {
+  static signUpMentor(req, res) {
+    const newId = parseInt(Mentors.length, 10) + 1;
+    const {
+      email, firstName, lastName, password, bio, address, occupation, expertise,
+    } = req.body;
+    const isAdmin = false;
+    const level = 'Mentor';
+    const newMentor = {
+      id: newId,
+      email,
+      firstName,
+      lastName,
+      password,
+      bio,
+      address,
+      occupation,
+      expertise,
+      isAdmin,
+      level,
+    };
+    Mentors.push(newMentor);
+    const token = jwt.sign({ id: newId, isAdmin, level }, ENV_VAR.APP_SECRET, {
+      expiresIn: '24h', // expires in 24 hours
+    });
+    return res.status(201).json({
+      message: 'Mentor created successfully!',
+      data: {
+        token,
+        message: 'Mentor created successfully!',
+      },
+    });
+  }
+
   static allMentors(req, res) {
     const mentors = Users.find((value) => value.level === 'Mentor');
 
@@ -17,6 +55,22 @@ class MentorsController {
     });
   }
 
+  /* static allMentors(req, res) {
+    const mentors = Users.find((value) => value.level === 'Mentor');
+
+    if (!mentors) {
+      return res.status(404).json({
+        status: 404,
+        message: 'No mentors found',
+      });
+    }
+    return res.status(200).json({
+      status: 200,
+      message: 'Mentors',
+      data: Mentors,
+    });
+  } */
+
   static getSingleMentor(req, res) {
     const { mentorId } = req.params;
     const mentor = Users.find((value) => value.id === Number(mentorId));
@@ -27,11 +81,58 @@ class MentorsController {
         error: 'Mentor not found',
       });
     }
-    return res.status(200).json({
-      status: 200,
-      message: 'Mentor',
-      data: mentor,
+    if (mentor.level === 'Mentor') {
+      return res.status(200).json({
+        status: 200,
+        message: 'Mentor',
+        data: mentor,
+      });
+    }
+    return res.status(404).json({
+      status: 404,
+      message: 'Given ID does not belong to a mentor',
     });
+  }
+
+  static logMentor(req, res) {
+    const { email, password } = req.body;
+    const logMentor = Mentors.find((item) => item.email === email);
+    if (logMentor) {
+      if (logMentor.password === password) {
+        const token = jwt.sign(
+          {
+            id: logMentor.id,
+            isAdmin: logMentor.isAdmin,
+            level: logMentor.level,
+          },
+          ENV_VAR.APP_SECRET,
+          {
+            expiresIn: '24h', // expires in 24 hours
+          },
+        );
+        res.json({
+          status: '200',
+          message: 'Mentor is successfully logged in!',
+          data: {
+            token,
+            id: logMentor.id,
+            firstName: logMentor.firstName,
+            lastName: logMentor.lastName,
+            email: logMentor.email,
+          },
+        });
+      } else {
+        res.status(400).json({
+          status: '400',
+          error: 'Password is incorrect',
+        });
+      }
+    } else {
+      res.status(400).json({
+        status: '400',
+        error: 'Email does not exist',
+      });
+    }
   }
 }
 

--- a/src/controllers/sessionController.js
+++ b/src/controllers/sessionController.js
@@ -1,0 +1,35 @@
+import Sessions from '../models/sessionModel';
+import validateMentorSession from './validations/createMentorshipRequest';
+
+class SessionController {
+  static createMentorshipRequest(req, res) {
+    const newId = parseInt(Sessions.length, 10) + 1;
+    const { id, email } = req.decoded;
+    const { mentorId, questions } = req.body;
+
+    const { valid, errors } = validateMentorSession(mentorId);
+    if (!valid) {
+      return res.status(400).json({
+        message: 'Validation errors',
+        errors,
+      });
+    }
+
+    const newSession = {
+      sessionId: newId,
+      mentorId,
+      menteeId: id,
+      questions,
+      menteeEmail: email,
+      status: 'Pending',
+    };
+    Sessions.push(newSession);
+
+    return res.status(201).json({
+      message: 'Session created successfully!',
+      data: newSession,
+    });
+  }
+}
+
+export default SessionController;

--- a/src/controllers/validations/createMentorshipRequest.js
+++ b/src/controllers/validations/createMentorshipRequest.js
@@ -1,0 +1,19 @@
+import Users from '../../models/authModel';
+
+const createMentorshipRequest = (mentorId) => {
+  const errors = {};
+
+  const mentorExists = Users.find((item) => item.id === Number(mentorId));
+
+  if (!mentorExists) {
+    errors.mentorId = `User with ID ${mentorId} not found`;
+  } else if (mentorExists.level !== 'Mentor') {
+    errors.mentorId = `User with ID ${mentorId} is not a mentor`;
+  }
+
+  return {
+    errors,
+    valid: Object.keys(errors).length < 1,
+  };
+};
+export default createMentorshipRequest;

--- a/src/controllers/validations/loginUser.js
+++ b/src/controllers/validations/loginUser.js
@@ -1,0 +1,22 @@
+import Users from '../../models/authModel';
+
+const loginUser = (email) => {
+  const errors = {};
+
+  const emailExists = Users.find((item) => item.email === email);
+
+  if (!emailExists) {
+    errors.email = 'email does not exist';
+  } else {
+    const regEx = /\S+@\S+\.\S+/;
+    if (!email.trim().match(regEx)) {
+      errors.email = 'Invalid email';
+    }
+  }
+
+  return {
+    errors,
+    valid: Object.keys(errors).length < 1,
+  };
+};
+export default loginUser;

--- a/src/controllers/validations/signUpUser.js
+++ b/src/controllers/validations/signUpUser.js
@@ -1,0 +1,25 @@
+import Users from '../../models/authModel';
+
+const validateSignUpUser = (email) => {
+  const errors = {};
+
+  const emailExists = Users.find((item) => item.email === email);
+
+  if (emailExists) {
+    errors.email = 'email already exists';
+  } else if (email.trim() === '') {
+    errors.email = 'email is required';
+  } else {
+    // Letters, numbers and underscore
+    const regEx = /\S+@\S+\.\S+/;
+    if (!email.trim().match(regEx)) {
+      errors.email = 'Invalid email';
+    }
+  }
+
+  return {
+    errors,
+    valid: Object.keys(errors).length < 1,
+  };
+};
+export default validateSignUpUser;

--- a/src/models/authModel.js
+++ b/src/models/authModel.js
@@ -12,6 +12,19 @@ const users = [
     isAdmin: true,
     level: 'Admin',
   },
+  {
+    id: 2,
+    email: 'user@user.com',
+    firstName: 'usr',
+    lastName: 'usr',
+    password: 'password',
+    bio: 'Admin Bio',
+    address: '282343',
+    occupation: 'Admin',
+    expertise: 'Admin',
+    isAdmin: false,
+    level: 'zdfgfhgjhk',
+  },
 ];
 
 export default users;

--- a/src/models/mentorModel.js
+++ b/src/models/mentorModel.js
@@ -1,0 +1,16 @@
+const mentors = [
+  {
+    id: 1,
+    email: 'admin@admin.com',
+    firstName: 'Admin',
+    lastName: 'Admin',
+    password: 'password',
+    bio: 'Admin Bio',
+    address: '282343',
+    occupation: 'Admin',
+    expertise: 'Admin',
+    isAdmin: true,
+    level: 'Admin',
+  },
+];
+export default mentors;

--- a/src/models/sessionModel.js
+++ b/src/models/sessionModel.js
@@ -1,0 +1,13 @@
+const sessions = [
+  /* data:
+    {
+        sessionId: Number(),
+        mentorId: '',
+        menteeId: '',
+        questions: '',
+        menteeEmail: '',
+        status:
+    } */
+];
+
+export default sessions;

--- a/src/routes/mentor.js
+++ b/src/routes/mentor.js
@@ -3,8 +3,8 @@ import mentorsController from '../controllers/mentorsController';
 
 const mentorRouter = express.Router();
 
-mentorRouter.post('/', (req, res) => res.send('user signup'));
-mentorRouter.post('/:mentorId', (req, res) => res.send('user signin'));
+mentorRouter.post('/signup', mentorsController.signUpMentor);
+mentorRouter.post('/:mentorId', mentorsController.logMentor);
 mentorRouter.get('/', mentorsController.allMentors);
 mentorRouter.get('/:mentorId', mentorsController.getSingleMentor);
 

--- a/src/routes/session.js
+++ b/src/routes/session.js
@@ -1,8 +1,10 @@
 import express from 'express';
+import sessionController from '../controllers/sessionController';
+import AuthRequired from '../middleware';
 
 const sessionRouter = express.Router();
 
-sessionRouter.post('/', (req, res) => res.send('create a mentor-session request'));
+sessionRouter.post('/', AuthRequired, sessionController.createMentorshipRequest);
 sessionRouter.patch('/:sessionId/accept', (req, res) => res.send('mentor accepted session request!'));
 sessionRouter.patch('/:sessionId/reject', (req, res) => res.send('mentor rejected session request!'));
 sessionRouter.post('/:sessionId/review', (req, res) => res.send('review posted!'));


### PR DESCRIPTION
#### What does this PR do?
- Have CRUD resource ***"CREATE"*** on REST API 

#### Description of Task to be completed?
- Have the following endpoint working:
```POST/api/v1/sessions```

#### How should this be manually tested?
- ```git-clone``` this repo, cd into it and ```npm run dev``` then on **Postman**, check the above endpoint by clicking *SEND*. It should return a ```status 201``` and a ***"session created!"*** message.

#### Any background context you want to provide?
- It also checks in with the relevant validations.

#### What are the relevant pivotal tracker stories?
- #168024660 ft-users-can-create-mentorship-session-requests

#### Screenshots (if appropriate)
- N/A
#### Questions:
- N/A