### PR TITLE
#168024689 mentors can accept session requests from mentees

### DIFF
--- a/src/controllers/sessionController.js
+++ b/src/controllers/sessionController.js
@@ -1,5 +1,6 @@
 import Sessions from '../models/sessionModel';
 import validateMentorSession from './validations/createMentorshipRequest';
+import validateSessionAcceptReq from './validations/validateSessionAcceptReq';
 
 class SessionController {
   static createMentorshipRequest(req, res) {
@@ -28,6 +29,38 @@ class SessionController {
     return res.status(201).json({
       message: 'Session created successfully!',
       data: newSession,
+    });
+  }
+
+  static acceptMentorshipRequest(req, res) {
+    const { id } = req.decoded;
+    const { sessionId } = req.params;
+
+    const { valid, errors } = validateSessionAcceptReq(id, sessionId);
+    if (!valid) {
+      return res.status(400).json({
+        errors,
+      });
+    }
+    const sessionExists = Sessions.find((item) => item.sessionid === Number(sessionId));
+
+    if (sessionExists.status === 'Accepted!') {
+      return res.json({
+        message: 'Session already accepted',
+      });
+    }
+
+    sessionExists.status = 'Accepted';
+    return res.status(200).json({
+      status: 200,
+      data: {
+        sessionId: sessionExists.id,
+        mentorId: sessionExists.mentorId,
+        menteeId: sessionExists.menteeId,
+        questions: sessionExists.questions,
+        menteeEmail: sessionExists.menteeEmail,
+        status: 'Accepted!',
+      },
     });
   }
 }

--- a/src/controllers/validations/validateSessionAcceptReq.js
+++ b/src/controllers/validations/validateSessionAcceptReq.js
@@ -1,0 +1,26 @@
+import Users from '../../models/authModel';
+import Sessions from '../../models/sessionModel';
+
+const validateMentorId = (mentorId, sessionId) => {
+  const errors = {};
+
+  const mentorExists = Users.find((item) => item.id === Number(mentorId));
+
+  const sessionExists = Sessions.find((item) => item.sessionId === Number(sessionId));
+
+  if (!mentorExists) {
+    errors.mentorId = `User with ID ${mentorId} not found`;
+  } else if (mentorExists.level !== 'Mentor') {
+    errors.mentorId = `User with ID ${mentorId} is not a mentor`;
+  }
+
+  if (!sessionExists) {
+    errors.sessionId = `Session with ID ${sessionId} not found`;
+  }
+
+  return {
+    errors,
+    valid: Object.keys(errors).length < 1,
+  };
+};
+export default validateMentorId;

--- a/src/routes/session.js
+++ b/src/routes/session.js
@@ -5,7 +5,7 @@ import AuthRequired from '../middleware';
 const sessionRouter = express.Router();
 
 sessionRouter.post('/', AuthRequired, sessionController.createMentorshipRequest);
-sessionRouter.patch('/:sessionId/accept', (req, res) => res.send('mentor accepted session request!'));
+sessionRouter.patch('/:sessionId/accept', AuthRequired, sessionController.acceptMentorshipRequest);
 sessionRouter.patch('/:sessionId/reject', (req, res) => res.send('mentor rejected session request!'));
 sessionRouter.post('/:sessionId/review', (req, res) => res.send('review posted!'));
 sessionRouter.delete('/:sessionId/review', (req, res) => res.send('review deleted!'));


### PR DESCRIPTION
#### What does this PR do?
- Have user request-response interaction capability on API

#### Description of Task to be completed?
- Creates the following endpoint set up and functioning:
```PATCH/api/v1/sessions/:sessionId/accept```

#### How should this be manually tested?
- ```git-clone``` and cd into this repo, ```npm run dev``` and test out the above endpoint using Postman. 

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- #168024689 ft-mentors-can-accept-session-requests

#### Screenshots (if appropriate)
- N/A

#### Questions:
- N/A