### PR TITLE
#168372203  Users can view a specific mentor 

### DIFF
--- a/src/controllers/mentorsController.js
+++ b/src/controllers/mentorsController.js
@@ -1,5 +1,4 @@
 import dotenv from 'dotenv';
-import Users from '../models/authModel';
 import pool from '../database/index';
 
 dotenv.config();
@@ -14,25 +13,42 @@ class MentorsController {
 
   static getSingleMentor(req, res) {
     const { mentorId } = req.params;
-    const mentor = Users.find((value) => value.id === Number(mentorId));
+    pool.query(
+      'SELECT * FROM users WHERE id = $1',
+      [mentorId],
+      (err, results) => {
+        if (results.rowCount < 1) {
+          return res.status(404).json({
+            status: 404,
+            error: `Mentor with ID ${mentorId} not found`,
+          });
+        }
+        return res.status(200).json({
+          status: 200,
+          data: results.rows,
+        });
+      },
 
-    if (!mentor) {
-      return res.status(404).json({
-        message: 'Error',
-        error: 'User not found',
-      });
-    }
-    if (mentor.level === 'Mentor') {
-      return res.status(200).json({
-        status: 200,
-        message: 'Mentor',
-        data: mentor,
-      });
-    }
-    return res.status(404).json({
-      status: 404,
-      message: 'Given ID does not belong to a mentor',
-    });
+      //   if (!mentor) {
+      //     return res.status(404).json({
+      //       message: 'Error',
+      //       error: 'User not found',
+      //     });
+      //   }
+      //   if (mentor.level === 'Mentor') {
+      //     return res.status(200).json({
+      //       status: 200,
+      //       message: 'Mentor',
+      //       data: mentor,
+      //     });
+      //   }
+      //   return res.status(404).json({
+      //     status: 404,
+      //     message: 'Given ID does not belong to a mentor',
+      //   });
+      //
+      // eslint-disable-next-line function-paren-newline
+    );
   }
 }
 

--- a/src/database/query.js
+++ b/src/database/query.js
@@ -11,8 +11,8 @@ const users = {
   isAdmin: "SELECT isadmin FROM users WHERE isadmin='true'",
   findAllMentors:
     "SELECT firstname, lastname, email, address, bio, occupation, expertise, isMentor, isAdmin FROM users WHERE isMentor='true'",
-  findOneMentor: "SELECT * FROM users WHERE isMentor='true' AND id=$1",
-  isMentorExist: "SELECT * FROM users WHERE id=$1 and isMentor='true'",
+  getspecificMentor: "SELECT * FROM users WHERE level = 'Mentor' AND id = $1",
+  isMentorExist: "SELECT * FROM users WHERE id=$1 and level = 'Mentor' = 'true'",
 };
 const sessions = {
   sessionExists: 'SELECT * FROM sessions WHERE  mentorId=$1 and questions=$2 and menteeId=$3',

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const swaggerDocument = require('./swagger.json');
 
 dotenv.config();
 
-const PORT = process.env.PORT || 4050;
+const PORT = process.env.PORT || 4060;
 
 const app = express();
 app.use(


### PR DESCRIPTION
#### What does this PR do?
- Have CRUD on resource endpoint ```GET/mentors/:mentorId```

### Description of Task to be completed?
- Set up controllers to perform the task of allowing users to be able to view specific mentors when they want to. Basically ensuring the endpoint route is functional and responsive on Postman and the database more importantly.

#### How should this be manually tested?
- ```git-clone``` this repo, cd into it and ```npm run dev```, then on Postman load and sign up a number of new users as per the parameters required, then basically on ```GET``` a specific mentor, type an existing ID of any mentors in the system and you should be able to view them.

#### Any background context you want to provide?
- Users refers to anyone using the app, that is inclusive of both mentors and mentees, as well as the admin.

#### What are the relevant pivotal tracker stories?
- #168372203  ft-a-user-can-view-a-specific

#### Screenshots (if appropriate)
- N/A
#### Questions:
- N/A