### PR TITLE
#168372417 Users can create mentor sessions - DB endpoint

### DIFF
--- a/src/controllers/mentorsController.js
+++ b/src/controllers/mentorsController.js
@@ -14,8 +14,8 @@ class MentorsController {
   static getSingleMentor(req, res) {
     const { mentorId } = req.params;
     pool.query(
-      'SELECT * FROM users WHERE id = $1',
-      [mentorId],
+      'SELECT * FROM users WHERE id = $1 AND level = $2',
+      [mentorId, 'Mentor'],
       (err, results) => {
         if (results.rowCount < 1) {
           return res.status(404).json({
@@ -28,26 +28,6 @@ class MentorsController {
           data: results.rows,
         });
       },
-
-      //   if (!mentor) {
-      //     return res.status(404).json({
-      //       message: 'Error',
-      //       error: 'User not found',
-      //     });
-      //   }
-      //   if (mentor.level === 'Mentor') {
-      //     return res.status(200).json({
-      //       status: 200,
-      //       message: 'Mentor',
-      //       data: mentor,
-      //     });
-      //   }
-      //   return res.status(404).json({
-      //     status: 404,
-      //     message: 'Given ID does not belong to a mentor',
-      //   });
-      //
-      // eslint-disable-next-line function-paren-newline
     );
   }
 }

--- a/src/controllers/validations/createMentorshipRequest.js
+++ b/src/controllers/validations/createMentorshipRequest.js
@@ -1,19 +1,20 @@
-import Users from '../../models/authModel';
+import pool from '../../database/database';
 
 const createMentorshipRequest = (mentorId) => {
   const errors = {};
 
-  const mentorExists = Users.find((item) => item.id === Number(mentorId));
-
-  if (!mentorExists) {
-    errors.mentorId = `User with ID ${mentorId} not found`;
-  } else if (mentorExists.level !== 'Mentor') {
-    errors.mentorId = `User with ID ${mentorId} is not a mentor`;
-  }
-
-  return {
-    errors,
-    valid: Object.keys(errors).length < 1,
-  };
+  pool.query(
+    'SELECT * FROM users WHERE id = $1 AND  level = $2',
+    [mentorId, 'Mentor'],
+    (err, results) => {
+      if (results.rowCount < 1) {
+        errors.mentorId = `Mentor with ID ${mentorId} not found`;
+      }
+      return {
+        errors,
+        valid: Object.keys(errors).length < 1,
+      };
+    },
+  );
 };
 export default createMentorshipRequest;

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -1,14 +1,5 @@
 /* eslint-disable no-console */
-import { Pool } from 'pg';
-import dotenv from 'dotenv';
-
-dotenv.config();
-
-const connectionString = process.env.DATABASE_URL;
-const pool = new Pool({
-  connectionString,
-});
-
+import pool from './index';
 // self invoking async function
 const tables = async () => {
   const dropTables = 'DROP TABLE IF EXISTS users, sessions';
@@ -27,13 +18,13 @@ const tables = async () => {
     isAdmin boolean DEFAULT false,
     createdOn TIMESTAMP DEFAULT CURRENT_TIMESTAMP
    )`;
-  const sessions = `CREATE TABLE IF NOT EXISTS properties (
+  const sessions = `CREATE TABLE IF NOT EXISTS sessions (
     id serial PRIMARY KEY,
     mentorId  VARCHAR(255) NOT NULL,
     menteeId  VARCHAR(255) NOT NULL DEFAULT 'available',
     questions  VARCHAR(255) NOT NULL,
-    menteeEmail VARCHAR(255) NOT NULL UNIQUE,
-    status TEXT,
+    menteeEmail VARCHAR(255) NOT NULL,
+    status TEXT DEFAULT 'pending',
     createdOn TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   )`;
 

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -9,3 +9,15 @@ const pool = new Pool({
 });
 
 export default pool;
+
+// import { Pool } from 'pg';
+
+// const conn = {
+//   user: process.env.DB_USER || 'kennedy',
+//   host: process.env.DB_HOST || 'localhost',
+//   database: process.env.DB_NAME || 'freementors',
+//   password: process.env.DB_PASS || 'password',
+//   port: 5432,
+// };
+
+// const pool = new Pool(conn);

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1,7 +1,7 @@
 {
 	"swagger": "2.0",
 	"info": {
-		"description": "Free Mentors is a social initiative where accomplished professionals become role models to young people to provide free mentorship sessions",
+		"description": "free-mentors is a social initiative where accomplished professionals become role models to young people to provide free mentorship sessions",
 		"version": "1.0.0",
 		"title": "free-mentors",
 		"termsOfService": "http://swagger.io/terms/",
@@ -14,48 +14,59 @@
 		}
 	},
 	"host": "localhost:4001",
-	"basePath": "/api/v1",
+	"basePath": "/api/v2",
 	"tags": [
 		{
 			"name": "user",
-			"description":"signup,login,change user to mentor"
+			"description":"signup,login"
 		},
 		{
 			"name": "Mentor",
-			"description":"view all mentors, view specific mentor"
+			"description":"view all mentor,view specific mentor"
 		},
 		{
 			"name": "sessions",
-			"description":"request, accept, reject, review"
+			"description":"create, request, accept, reject, and review mentor-sessions"
+
+		},
+		{
+			"name": "reviews",
+			"description":"review mentor, delete review"
 
 		}
 	],
 	"schemes": [
+		"https",
 
 		"http"
 	],
+	"consumes": [
+		"application/json"
+	],
+	"produces": [
+		"application/json"
+	],
 	"paths": {
-		"/signup": {
+		"auth/signup": {
 			"post": {
 				"tags": [
 					"user"
 				],
-				"summary": "Create user account",
+				"summary": "Create new user account",
 				"description": "this endpoint will will be used to create a new account",
-				"operationId": "adduser",
+				"operationId": "authSignUp",
+				"deprecated": false,
 				"consumes": [
-					"application/xml",
 					"application/json"
-				
 				],
 				"produces": [
-					"application/xml",
-					"application/json"
+					"application/xml"
 				],
 				"parameters": [
 					{
-						"in": "body",
-						"name": "body",
+						"in": "header",
+						"type": "string",
+						"name": "firstName",
 						"description": "User object that nedded to create account",
 						"required": true,
 						"schema": {
@@ -65,7 +76,7 @@
 				],
 				"responses": {
 					"201": {
-						"description": "Account created succesfully"
+						"description": "Account created successfully"
 					},
 					"400": {
 						"description": "bad request | Invalid input"
@@ -85,16 +96,15 @@
 				"tags": [
 					"user"
 				],
-				"summary": "user signin",
-				"description": "this endpoint a registered user can be able to sign in",
+				"summary": "authSignIn",
+				"description": "this endpoint allows user to be able to sign in",
 				"operationId": "signin",
+				"deprecated": false,
 				"consumes": [
-					"application/json",
-					"application/xml"
+					"application/json"
 				],
 				"produces": [
-					"application/json",
-					"application/xml"
+					"application/json"
 				],
 				"parameters": [
 					{
@@ -201,14 +211,14 @@
 						"example":{
 							
 								"id":"1",
-								"firstName": "mugiraneza",
-								"lastName": "john",
-								"email": "mujohn26@gmail.com",
-								"password": "mugiraneza",
-								"address": "kigali",
-								"bio": "born Nyagatare",
+								"firstName": "Kennedy",
+								"lastName": "Simiyu",
+								"email": "nyongesa17@outlook.com",
+								"password": "password",
+								"address": "123 ABC Place",
+								"bio": "bio goes here...",
 								"occupation": "student",
-								"expertise": "tech"
+								"expertise": "Software Dev"
 
 							  
 						}


### PR DESCRIPTION
#### What does this PR do?
- Have CRUD function *CREATE* integrated to database.

#### Description of Task to be completed?
- Have users able to create mentor session - requests with mentors.

#### How should this be manually tested?
- ```npm run db:migrate``` to drop and start tables afresh. ```npm run db:migrate-users``` to instantiate the admin to existence and then follow through with ```npm run dev``` the.
- Open up on Postman and go through the routes and then check the create session with the authorization from user tokens.
 
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- #168372417 ft-users-can-create-mentor-sessions

#### Screenshots (if appropriate)
- N/A
#### Questions:
- N/A